### PR TITLE
fix: stop compressing release binaries with upx

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,31 +6,8 @@ builds:
 
     targets:
       - darwin_amd64
-      - linux_amd64
-
-    flags:
-      - -buildvcs=false
-      - -trimpath
-
-    ldflags:
-      - -s -w
-      - -buildid=
-      - -X jdk.sh/meta.date={{ .Date }}
-      - -X jdk.sh/meta.sha={{ .Commit }}
-      - -X jdk.sh/meta.version={{ .Tag }}
-
-    env:
-      - CGO_ENABLED=0
-
-    hooks:
-      post:
-        - upx --best --ultra-brute "{{ .Path }}"
-
-  - id: aws-saml-m1
-    binary: aws-saml
-
-    targets:
       - darwin_arm64
+      - linux_amd64
 
     flags:
       - -buildvcs=false


### PR DESCRIPTION
This repo has been using [upx/upx](https://github.com/upx/upx) to compress release binaries.

Binaries for `darwin-arm64` hav not worked historically, and were never compressed. Recently binaries for `darwin-amd64` no longer work for users who have upgraded to macOS Ventura.

For this reason it no longer makes sense to compress binaries. We were also only saving about 1mb anyway 🙃 

See https://github.com/upx/upx/issues/612 for tracking the upstream issue.